### PR TITLE
hfp: Report SCO sample rate via g_sco_samplerate audio param if needed

### DIFF
--- a/res/values/config.xml
+++ b/res/values/config.xml
@@ -135,4 +135,6 @@
      -->
     <bool name="enable_gd_up_to_scanning_layer">false</bool>
 
+    <!-- If true, SCO sample rate will be reported via g_sco_samplerate audio parameter -->
+    <bool name="sco_report_samplerate">false</bool>
 </resources>

--- a/src/com/android/bluetooth/btservice/AdapterService.java
+++ b/src/com/android/bluetooth/btservice/AdapterService.java
@@ -4006,4 +4006,8 @@ public class AdapterService extends Service {
     public boolean isMock() {
         return false;
     }
+
+    public boolean shouldReportScoSampleRate() {
+        return getResources().getBoolean(com.android.bluetooth.R.bool.sco_report_samplerate);
+    }
 }

--- a/src/com/android/bluetooth/hfp/HeadsetStateMachine.java
+++ b/src/com/android/bluetooth/hfp/HeadsetStateMachine.java
@@ -87,6 +87,9 @@ public class HeadsetStateMachine extends StateMachine {
     private static final String HEADSET_WBS = "bt_wbs";
     private static final String HEADSET_AUDIO_FEATURE_ON = "on";
     private static final String HEADSET_AUDIO_FEATURE_OFF = "off";
+    private static final String HEADSET_G_SCO_SAMPLERATE = "g_sco_samplerate";
+    private static final String HEADSET_G_WB_SAMPLERATE = "16000";
+    private static final String HEADSET_G_NB_SAMPLERATE = "8000";
 
     static final int CONNECT = 1;
     static final int DISCONNECT = 2;
@@ -1549,6 +1552,10 @@ public class HeadsetStateMachine extends StateMachine {
                 HEADSET_WBS + "=" + mAudioParams.getOrDefault(HEADSET_WBS,
                         HEADSET_AUDIO_FEATURE_OFF)
         });
+        if (mAdapterService.shouldReportScoSampleRate()) {
+            keyValuePairs += ";" + HEADSET_G_SCO_SAMPLERATE + "=" + mAudioParams.getOrDefault(
+                    HEADSET_G_SCO_SAMPLERATE, HEADSET_G_NB_SAMPLERATE);
+        }
         Log.i(TAG, "setAudioParameters for " + mDevice + ": " + keyValuePairs);
         mSystemInterface.getAudioManager().setParameters(keyValuePairs);
     }
@@ -1690,10 +1697,16 @@ public class HeadsetStateMachine extends StateMachine {
         switch (wbsConfig) {
             case HeadsetHalConstants.BTHF_WBS_YES:
                 mAudioParams.put(HEADSET_WBS, HEADSET_AUDIO_FEATURE_ON);
+                if (mAdapterService.shouldReportScoSampleRate()) {
+                    mAudioParams.put(HEADSET_G_SCO_SAMPLERATE, HEADSET_G_WB_SAMPLERATE);
+                }
                 break;
             case HeadsetHalConstants.BTHF_WBS_NO:
             case HeadsetHalConstants.BTHF_WBS_NONE:
                 mAudioParams.put(HEADSET_WBS, HEADSET_AUDIO_FEATURE_OFF);
+                if (mAdapterService.shouldReportScoSampleRate()) {
+                    mAudioParams.put(HEADSET_G_SCO_SAMPLERATE, HEADSET_G_NB_SAMPLERATE);
+                }
                 break;
             default:
                 Log.e(TAG, "processWBSEvent: unknown wbsConfig " + wbsConfig);


### PR DESCRIPTION
On Samsung devices, we need to tell Audio HAL if we're running narrow
band or wide band.

Change-Id: Ibfa0f632d9acbb920a85a613ce4e2f1d26556bd1
Signed-off-by: SamarV-121 <samarvispute121@pm.me>